### PR TITLE
feat: implement the family flag for restricting tcp family

### DIFF
--- a/lib/proxy/http.js
+++ b/lib/proxy/http.js
@@ -30,6 +30,7 @@ class HttpProxy {
         delete opts.path
         // we also delete the timeout since we control it ourselves
         delete opts.timeout
+        opts.family = this.agent.options.family
         opts.lookup = this.lookup
 
         if (this.url.protocol === 'https:') {

--- a/lib/proxy/null.js
+++ b/lib/proxy/null.js
@@ -19,8 +19,8 @@ class NullProxy {
 
   createConnection (options, callback) {
     const socket = this.secure
-      ? tls.connect({ ...options, lookup: this.lookup })
-      : net.connect({ ...options, lookup: this.lookup })
+      ? tls.connect({ ...options, family: this.agent.options.family, lookup: this.lookup })
+      : net.connect({ ...options, family: this.agent.options.family, lookup: this.lookup })
 
     socket.setKeepAlive(this.agent.keepAlive, this.agent.keepAliveMsecs)
     socket.setNoDelay(this.agent.keepAlive)

--- a/lib/util.js
+++ b/lib/util.js
@@ -18,6 +18,7 @@ const normalizeOptions = (_options) => {
     delete options.timeout
   }
 
+  options.family = !isNaN(+options.family) ? +options.family : 0
   options.dns = {
     ttl: 5 * 60 * 1000,
     lookup: dns.lookup,

--- a/test/fixtures/proxy.js
+++ b/test/fixtures/proxy.js
@@ -17,8 +17,9 @@ const _onConnect = Symbol('Proxy._onConnect')
 const _onConnection = Symbol('Proxy._onConnection')
 
 class Proxy extends EventEmitter {
-  constructor ({ auth, tls: _tls, failConnect } = {}) {
+  constructor ({ auth, tls: _tls, family, failConnect } = {}) {
     super()
+    this.family = typeof family === 'number' ? family : 0
     this.failConnect = !!failConnect
     this.auth = !!auth
     if (this.auth) {
@@ -42,7 +43,18 @@ class Proxy extends EventEmitter {
   }
 
   async start () {
-    this.server.listen(0, 'localhost')
+    let host
+    if (this.family === 0) {
+      host = 'localhost'
+    } else if (this.family === 4) {
+      host = '127.0.0.1'
+    } else if (this.family === 6) {
+      host = '::1'
+    }
+    this.server.listen({
+      port: 0,
+      host,
+    })
     await once(this.server, 'listening')
 
     const address = this.server.address()

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -11,8 +11,9 @@ const _onConnection = Symbol('Server._onConnection')
 const _onRequest = Symbol('Server._onRequest')
 
 class Server extends EventEmitter {
-  constructor ({ auth, tls, responseDelay, idleDelay, transferDelay } = {}) {
+  constructor ({ auth, tls, family, responseDelay, idleDelay, transferDelay } = {}) {
     super()
+    this.family = typeof family === 'number' ? family : 0
     this.responseDelay = responseDelay || 0
     this.idleDelay = idleDelay || 0
     this.transferDelay = transferDelay || 0
@@ -40,7 +41,18 @@ class Server extends EventEmitter {
   }
 
   async start () {
-    this.server.listen(0, 'localhost')
+    let host
+    if (this.family === 0) {
+      host = 'localhost'
+    } else if (this.family === 4) {
+      host = '127.0.0.1'
+    } else if (this.family === 6) {
+      host = '::1'
+    }
+    this.server.listen({
+      port: 0,
+      host,
+    })
     await once(this.server, 'listening')
 
     const address = this.server.address()

--- a/test/http-proxy.js
+++ b/test/http-proxy.js
@@ -32,6 +32,54 @@ t.test('http destination', (t) => {
     t.equal(res.result, 'OK!')
   })
 
+  t.test('single request ipv4 only', async (t) => {
+    const server = new Server()
+    await server.start()
+
+    const proxy = new Proxy({ family: 4 })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpAgent({ family: 4, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpAgent({ family: 6, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
+  t.test('single request ipv6 only', async (t) => {
+    const server = new Server()
+    await server.start()
+
+    const proxy = new Proxy({ family: 6 })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpAgent({ family: 6, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpAgent({ family: 4, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
   t.test('can disable keep-alive', async (t) => {
     const server = new Server()
     await server.start()
@@ -303,6 +351,54 @@ t.test('https destination', (t) => {
     t.equal(res.status, 200)
     t.equal(res.headers.get('connection'), 'keep-alive', 'keep-alive by default')
     t.equal(res.result, 'OK!')
+  })
+
+  t.test('single request ipv4 only', async (t) => {
+    const server = new Server({ tls: true })
+    await server.start()
+
+    const proxy = new Proxy({ family: 4 })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpsAgent({ family: 4, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpsAgent({ family: 6, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
+  t.test('single request ipv6 only', async (t) => {
+    const server = new Server({ tls: true })
+    await server.start()
+
+    const proxy = new Proxy({ family: 6 })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpsAgent({ family: 6, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpsAgent({ family: 4, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
   })
 
   t.test('can disable keep-alive', async (t) => {

--- a/test/https-proxy.js
+++ b/test/https-proxy.js
@@ -32,6 +32,54 @@ t.test('http destination', (t) => {
     t.equal(res.result, 'OK!')
   })
 
+  t.test('single request ipv4 only', async (t) => {
+    const server = new Server()
+    await server.start()
+
+    const proxy = new Proxy({ family: 4, tls: true })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpAgent({ family: 4, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpAgent({ family: 6, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
+  t.test('single request ipv6 only', async (t) => {
+    const server = new Server()
+    await server.start()
+
+    const proxy = new Proxy({ family: 6, tls: true })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpAgent({ family: 6, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpAgent({ family: 4, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
   t.test('can disable keep-alive', async (t) => {
     const server = new Server()
     await server.start()
@@ -323,6 +371,54 @@ t.test('https destination', (t) => {
     t.equal(res.status, 200)
     t.equal(res.headers.get('connection'), 'keep-alive', 'keep-alive by default')
     t.equal(res.result, 'OK!')
+  })
+
+  t.test('single request ipv4 only', async (t) => {
+    const server = new Server({ tls: true })
+    await server.start()
+
+    const proxy = new Proxy({ family: 4, tls: true })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpsAgent({ family: 4, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpsAgent({ family: 6, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
+  t.test('single request ipv6 only', async (t) => {
+    const server = new Server({ tls: true })
+    await server.start()
+
+    const proxy = new Proxy({ family: 6, tls: true })
+    await proxy.start()
+
+    t.teardown(async () => {
+      await server.stop()
+      await proxy.stop()
+    })
+
+    const agent = new HttpsAgent({ family: 6, proxy: proxy.address })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpsAgent({ family: 4, proxy: proxy.address })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
   })
 
   t.test('can disable keep-alive', async (t) => {

--- a/test/null-proxy.js
+++ b/test/null-proxy.js
@@ -27,6 +27,46 @@ t.test('http destination', (t) => {
     t.equal(res.result, 'OK!')
   })
 
+  t.test('single request ipv4 only', async (t) => {
+    const server = new Server({ family: 4 })
+    await server.start()
+
+    t.teardown(async () => {
+      await server.stop()
+    })
+
+    const agent = new HttpAgent({ family: 4 })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpAgent({ family: 6 })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
+  t.test('single request ipv6 only', async (t) => {
+    const server = new Server({ family: 6 })
+    await server.start()
+
+    t.teardown(async () => {
+      await server.stop()
+    })
+
+    const agent = new HttpAgent({ family: 6 })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpAgent({ family: 4 })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
   t.test('can disable keep-alive', async (t) => {
     const server = new Server()
     await server.start()
@@ -204,6 +244,46 @@ t.test('https destination', (t) => {
     t.equal(res.status, 200)
     t.equal(res.headers.get('connection'), 'keep-alive', 'keep-alive by default')
     t.equal(res.result, 'OK!')
+  })
+
+  t.test('single request ipv4 only', async (t) => {
+    const server = new Server({ tls: true, family: 4 })
+    await server.start()
+
+    t.teardown(async () => {
+      await server.stop()
+    })
+
+    const agent = new HttpsAgent({ family: 4 })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpsAgent({ family: 6 })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
+  })
+
+  t.test('single request ipv6 only', async (t) => {
+    const server = new Server({ tls: true, family: 6 })
+    await server.start()
+
+    t.teardown(async () => {
+      await server.stop()
+    })
+
+    const agent = new HttpsAgent({ family: 6 })
+    const client = new Client(agent, server.address)
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const mismatchAgent = new HttpsAgent({ family: 4 })
+    const mismatchClient = new Client(mismatchAgent, server.address)
+    await t.rejects(mismatchClient.get('/'), { code: 'ECONNREFUSED' })
   })
 
   t.test('can disable keep-alive', async (t) => {

--- a/test/options.js
+++ b/test/options.js
@@ -5,6 +5,14 @@ const t = require('tap')
 const { normalizeOptions } = require('../lib/util.js')
 
 t.test('normalizeOptions', (t) => {
+  t.test('family', (t) => {
+    t.hasStrict(normalizeOptions({}), { family: 0 })
+    t.hasStrict(normalizeOptions({ family: 4 }), { family: 4 })
+    t.hasStrict(normalizeOptions({ family: '6' }), { family: 6 })
+    t.hasStrict(normalizeOptions({ family: 'nope' }), { family: 0 })
+    t.end()
+  })
+
   t.test('replaces timeout with timeouts.idle', (t) => {
     const options = normalizeOptions({ timeout: 100 })
     t.hasStrict(options, { timeouts: { idle: 100 } })


### PR DESCRIPTION
this allows requests to be forced to either ipv4 or ipv6
