### PR TITLE
feat: implement getAgent function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,135 @@
 'use strict'
 
+const { normalizeOptions } = require('./util.js')
 const HttpAgent = require('./http.js')
 const HttpsAgent = require('./https.js')
 
+const AgentCache = new Map()
+
+const proxyEnv = {}
+for (const [key, value] of Object.entries(process.env)) {
+  const lowerKey = key.toLowerCase()
+  if (['https_proxy', 'http_proxy', 'proxy', 'no_proxy'].includes(lowerKey)) {
+    proxyEnv[lowerKey] = value
+  }
+}
+
+const getAgent = (url, options) => {
+  url = new URL(url)
+  options = normalizeOptions(options)
+
+  // false has meaning so this can't be a simple truthiness check
+  if (options.agent != null) {
+    return options.agent
+  }
+
+  const isHttps = url.protocol === 'https:'
+
+  let proxy = options.proxy
+  if (!proxy) {
+    proxy = isHttps
+      ? proxyEnv.https_proxy
+      : (proxyEnv.https_proxy || proxyEnv.http_proxy || proxyEnv.proxy)
+  }
+
+  if (proxy) {
+    proxy = new URL(proxy)
+    let noProxy = options.noProxy || proxyEnv.no_proxy
+    if (typeof noProxy === 'string') {
+      noProxy = noProxy.split(',').map((p) => p.trim())
+    }
+
+    if (noProxy) {
+      const hostSegments = url.hostname.split('.').reverse()
+      const matches = noProxy.some((no) => {
+        const noSegments = no.split('.').filter(Boolean).reverse()
+        if (!noSegments.length) {
+          return false
+        }
+
+        for (let i = 0; i < noSegments.length; ++i) {
+          if (hostSegments[i] !== noSegments[i]) {
+            return false
+          }
+        }
+
+        return true
+      })
+
+      if (matches) {
+        proxy = ''
+      }
+    }
+  }
+
+  const timeouts = [
+    options.timeouts.connection || 0,
+    options.timeouts.idle || 0,
+    options.timeouts.response || 0,
+    options.timeouts.transfer || 0,
+  ].join('.')
+
+  const maxSockets = options.maxSockets || 15
+
+  let proxyDescriptor = 'proxy:'
+  if (!proxy) {
+    proxyDescriptor += 'null'
+  } else {
+    proxyDescriptor += `${proxy.protocol}//`
+    let auth = ''
+
+    if (proxy.username) {
+      auth += proxy.username
+    }
+
+    if (proxy.password) {
+      auth += `:${proxy.password}`
+    }
+
+    if (auth) {
+      proxyDescriptor += `${auth}@`
+    }
+
+    proxyDescriptor += proxy.host
+  }
+
+  const key = [
+    `https:${isHttps}`,
+    proxyDescriptor,
+    `local-address:${options.localAddress || 'null'}`,
+    `strict-ssl:${isHttps ? options.rejectUnauthorized : 'false'}`,
+    `ca:${isHttps && options.ca || 'null'}`,
+    `cert:${isHttps && options.cert || 'null'}`,
+    `key:${isHttps && options.key || 'null'}`,
+    `timeouts:${timeouts}`,
+    `maxSockets:${maxSockets}`,
+  ].join(':')
+
+  if (AgentCache.has(key)) {
+    return AgentCache.get(key)
+  }
+
+  const agentOptions = {
+    ca: options.ca,
+    cert: options.cert,
+    key: options.key,
+    rejectUnauthorized: options.rejectUnauthorized,
+    maxSockets,
+    timeouts: options.timeouts,
+    localAddress: options.localAddress,
+    proxy,
+  }
+
+  const agent = isHttps
+    ? new HttpsAgent(agentOptions)
+    : new HttpAgent(agentOptions)
+
+  AgentCache.set(key, agent)
+  return agent
+}
+
 module.exports = {
+  getAgent,
   HttpAgent,
   HttpsAgent,
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,10 +2,249 @@
 
 const t = require('tap')
 
-const HttpAgent = require('../lib/http.js')
-const HttpsAgent = require('../lib/https.js')
+const {
+  getAgent,
+  HttpAgent,
+  HttpsAgent,
+} = require('../lib/index.js')
 
-t.test('http destination', (t) => {
+t.test('getAgent', (t) => {
+  t.test('returns HttpAgent for http url', (t) => {
+    const agent = getAgent('http://localhost')
+    t.type(agent, HttpAgent)
+    t.end()
+  })
+
+  t.test('returns HttpsAgent for https url', (t) => {
+    const agent = getAgent('https://localhost')
+    t.type(agent, HttpsAgent)
+    t.end()
+  })
+
+  t.test('returns false when agent is false', (t) => {
+    const agent = getAgent('http://localhost', { agent: false })
+    t.equal(agent, false)
+    t.end()
+  })
+
+  t.test('maxSockets defaults to 15', (t) => {
+    const agent = getAgent('http://localhost', {})
+    t.equal(agent.options.maxSockets, 15)
+    t.end()
+  })
+
+  t.test('respects provided proxy option', (t) => {
+    const agent = getAgent('http://localhost', { proxy: 'http://localhost:8080' })
+    t.type(agent, HttpAgent)
+    t.hasStrict(agent, {
+      proxy: {
+        url: {
+          protocol: 'http:',
+          hostname: 'localhost',
+          port: '8080',
+        },
+      },
+    })
+    t.end()
+  })
+
+  t.test('respects https_proxy for https target', (t) => {
+    process.env.https_proxy = 'https://localhost'
+    t.teardown(() => {
+      delete process.env.https_proxy
+    })
+
+    const { getAgent: getEnvAgent, HttpsAgent: EnvHttpsAgent } = t.mock('../lib/index.js')
+
+    const agent = getEnvAgent('https://localhost')
+    t.type(agent, EnvHttpsAgent)
+    t.hasStrict(agent, {
+      proxy: {
+        url: {
+          protocol: 'https:',
+          hostname: 'localhost',
+          port: '',
+        },
+      },
+    })
+
+    t.end()
+  })
+
+  t.test('respects https_proxy for http target', (t) => {
+    process.env.https_proxy = 'https://localhost'
+    t.teardown(() => {
+      delete process.env.https_proxy
+    })
+
+    const { getAgent: getEnvAgent, HttpAgent: EnvHttpAgent } = t.mock('../lib/index.js')
+
+    const agent = getEnvAgent('http://localhost')
+    t.type(agent, EnvHttpAgent)
+    t.hasStrict(agent, {
+      proxy: {
+        url: {
+          protocol: 'https:',
+          hostname: 'localhost',
+          port: '',
+        },
+      },
+    })
+
+    t.end()
+  })
+
+  t.test('respects http_proxy for http target', (t) => {
+    process.env.http_proxy = 'http://localhost'
+    t.teardown(() => {
+      delete process.env.http_proxy
+    })
+
+    const { getAgent: getEnvAgent, HttpAgent: EnvHttpAgent } = t.mock('../lib/index.js')
+
+    const agent = getEnvAgent('http://localhost')
+    t.type(agent, EnvHttpAgent)
+    t.hasStrict(agent, {
+      proxy: {
+        url: {
+          protocol: 'http:',
+          hostname: 'localhost',
+          port: '',
+        },
+      },
+    })
+
+    t.end()
+  })
+
+  t.test('respects proxy for http target', (t) => {
+    process.env.proxy = 'http://localhost'
+    t.teardown(() => {
+      delete process.env.proxy
+    })
+
+    const { getAgent: getEnvAgent, HttpAgent: EnvHttpAgent } = t.mock('../lib/index.js')
+
+    const agent = getEnvAgent('http://localhost')
+    t.type(agent, EnvHttpAgent)
+    t.hasStrict(agent, {
+      proxy: {
+        url: {
+          protocol: 'http:',
+          hostname: 'localhost',
+          port: '',
+        },
+      },
+    })
+
+    t.end()
+  })
+
+  t.test('ignores http_proxy for https target', (t) => {
+    process.env.http_proxy = 'http://localhost'
+    t.teardown(() => {
+      delete process.env.http_proxy
+    })
+
+    const { getAgent: getEnvAgent, HttpsAgent: EnvHttpsAgent } = t.mock('../lib/index.js')
+
+    const agent = getEnvAgent('https://localhost')
+    t.type(agent, EnvHttpsAgent)
+    t.notOk(agent.proxy.url)
+
+    t.end()
+  })
+
+  t.test('ignores proxy for https target', (t) => {
+    process.env.proxy = 'http://localhost'
+    t.teardown(() => {
+      delete process.env.proxy
+    })
+
+    const { getAgent: getEnvAgent, HttpsAgent: EnvHttpsAgent } = t.mock('../lib/index.js')
+
+    const agent = getEnvAgent('https://localhost')
+    t.type(agent, EnvHttpsAgent)
+    t.notOk(agent.proxy.url)
+
+    t.end()
+  })
+
+  t.test('respects noProxy option when passed', (t) => {
+    const agentOne = getAgent('http://google.com', {
+      proxy: 'http://localhost',
+      noProxy: 'google.com',
+    })
+    t.type(agentOne, HttpAgent)
+    t.notOk(agentOne.proxy.url)
+
+    const agentTwo = getAgent('http://localhost', {
+      proxy: 'http://localhost',
+      noProxy: 'google.com',
+    })
+    t.type(agentTwo, HttpAgent)
+    t.ok(agentTwo.proxy.url)
+
+    // this ensures that an empty string in noProxy has no negative effect
+    const agentThree = getAgent('http://localhost', {
+      proxy: 'http://localhost',
+      noProxy: [''],
+    })
+    t.type(agentThree, HttpAgent)
+    t.ok(agentThree.proxy.url)
+
+    t.end()
+  })
+
+  t.test('respects no_proxy env var', (t) => {
+    process.env.no_proxy = 'google.com'
+    t.teardown(() => {
+      delete process.env.no_proxy
+    })
+
+    const { getAgent: getEnvAgent, HttpsAgent: EnvHttpsAgent } = t.mock('../lib/index.js')
+
+    const agentOne = getEnvAgent('https://google.com', {
+      proxy: 'https://localhost',
+    })
+    t.type(agentOne, EnvHttpsAgent)
+    t.notOk(agentOne.proxy.url)
+
+    const agentTwo = getEnvAgent('https://localhost', {
+      proxy: 'https://localhost',
+    })
+    t.type(agentTwo, EnvHttpsAgent)
+    t.ok(agentTwo.proxy.url)
+
+    t.end()
+  })
+
+  t.test('returns same agent for same proxy and destination type', (t) => {
+    const agentOne = getAgent('http://localhost', { proxy: 'http://user1:pass1@localhost' })
+    t.type(agentOne, HttpAgent)
+
+    const agentTwo = getAgent('http://localhost', { proxy: 'http://user1:pass1@localhost' })
+    t.type(agentTwo, HttpAgent)
+
+    t.equal(agentOne, agentTwo)
+    t.end()
+  })
+
+  t.test('returns different agents when auth differs', (t) => {
+    const agentOne = getAgent('http://localhost', { proxy: 'http://user1:pass1@localhost' })
+    t.type(agentOne, HttpAgent)
+
+    const agentTwo = getAgent('http://localhost', { proxy: 'http://user2:pass2@localhost' })
+    t.type(agentTwo, HttpAgent)
+
+    t.not(agentOne, agentTwo)
+    t.end()
+  })
+
+  t.end()
+})
+
+t.test('http agent', (t) => {
   t.test('throws for incompatible proxy protocols', async (t) => {
     t.throws(() => {
       new HttpAgent({ proxy: 'foo://not-supported' })
@@ -15,7 +254,7 @@ t.test('http destination', (t) => {
   t.end()
 })
 
-t.test('https destination', (t) => {
+t.test('https agent', (t) => {
   t.test('throws for incompatible proxy protocols', async (t) => {
     t.throws(() => {
       new HttpsAgent({ proxy: 'foo://not-supported' })


### PR DESCRIPTION
note that i chose to remove the lambda specific handling, it doesn't make much sense to me to arbitrarily turn off keepalives just because a fetch is being performed in a lambda.

other than that, this is meant to be functionally equivalent to the `lib/agent.js` file in `make-fetch-happen`
