### PR TITLE
fix: use current agent to determine secure proxy

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -27,8 +27,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Install npm@latest
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install npm@next-9
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -82,8 +82,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Install npm@latest
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install npm@next-9
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -194,9 +194,9 @@ jobs:
       - name: Install npm@7
         if: startsWith(matrix.node-version, '10.')
         run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
+      - name: Install npm@next-9
         if: ${{ !startsWith(matrix.node-version, '10.') }}
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Install npm@latest
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install npm@next-9
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -91,9 +91,9 @@ jobs:
       - name: Install npm@7
         if: startsWith(matrix.node-version, '10.')
         run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
+      - name: Install npm@next-9
         if: ${{ !startsWith(matrix.node-version, '10.') }}
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Install npm@latest
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install npm@next-9
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,8 +31,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Install npm@latest
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install npm@next-9
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Install npm@latest
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install npm@next-9
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -157,8 +157,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - name: Install npm@latest
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install npm@next-9
+        run: npm i --prefer-online --no-fund --no-audit -g npm@next-9
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/lib/agents.js
+++ b/lib/agents.js
@@ -7,7 +7,7 @@ const tls = require('tls')
 const { once } = require('events')
 const { createTimeout, abortRace, urlify, appendPort, cacheAgent } = require('./util')
 const { normalizeOptions, cacheOptions } = require('./options')
-const { getProxy, getProxyType, isSecureProxy, proxyCache } = require('./proxy.js')
+const { getProxy, getProxyType, proxyCache } = require('./proxy.js')
 const Errors = require('./errors.js')
 
 const createAgent = (base, name) => {
@@ -43,18 +43,16 @@ const createAgent = (base, name) => {
         return
       }
 
-      const secure = isSecureProxy(proxy)
-
       return cacheAgent({
         key: cacheOptions({
           ...options,
           ...this.#options,
-          secure,
+          secure: SECURE,
           timeouts: this.#timeouts,
           proxy,
         }),
         cache: proxyCache,
-        secure,
+        secure: SECURE,
         proxies: this.#proxy.proxies,
       }, proxy, this.#options)
     }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -22,13 +22,6 @@ const PROXY_ENV = (() => {
 })()
 
 const SOCKS_PROTOCOLS = new Set(SocksProxyAgent.protocols)
-const SECURE_PROTOCOLS = new Set([...SocksProxyAgent.protocols, 'https'])
-
-const isSecureProxy = (url) => {
-  url = urlify(url)
-  const protocol = url.protocol.slice(0, -1)
-  return SECURE_PROTOCOLS.has(protocol)
-}
 
 const getProxyType = (url) => {
   url = urlify(url)
@@ -91,6 +84,5 @@ const getProxy = (url, {
 module.exports = {
   getProxyType,
   getProxy,
-  isSecureProxy,
   proxyCache: PROXY_CACHE,
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "16.x",
       "18.0.0",
       "18.x"
-    ]
+    ],
+    "npmSpec": "next-9"
   },
   "dependencies": {
     "http-proxy-agent": "^7.0.0",


### PR DESCRIPTION
This matches the old behavior of `make-fetch-happen@11.1.1`[1] where the
proxy agent was determined based on the original request url.

Fixes npm/cli#6760

[1]: https://github.com/npm/make-fetch-happen/blob/eb4a83806e9deb7e441c8f2f6a673f929055a5eb/lib/agent.js#L195C1-L195C1
