### PR TITLE
chore: re-implement skipped windows test

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@npmcli/template-oss": "4.21.3",
     "minipass-fetch": "^3.0.3",
     "nock": "^13.2.7",
-    "semver": "^7.5.4",
     "simple-socks": "^3.1.0",
     "tap": "^16.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "minipass-fetch": "^3.0.3",
     "nock": "^13.2.7",
     "simple-socks": "^3.1.0",
+    "socksv5": "^0.0.6",
     "tap": "^16.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@npmcli/template-oss": "4.21.3",
     "minipass-fetch": "^3.0.3",
     "nock": "^13.2.7",
-    "simple-socks": "^3.1.0",
     "socksv5": "^0.0.6",
     "tap": "^16.3.0"
   },

--- a/test/agent.js
+++ b/test/agent.js
@@ -2,11 +2,8 @@
 
 const t = require('tap')
 const timers = require('timers/promises')
-const semver = require('semver')
 const dns = require('dns')
 const { createSetup, mockConnect } = require('./fixtures/setup.js')
-
-const isWindows = process.platform === 'win32'
 
 const agentTest = (t, opts) => {
   const { setup, hasProxy, isSocks } = createSetup(opts)
@@ -174,12 +171,7 @@ const agentTest = (t, opts) => {
       })
 
       if (isSocks) {
-        // weird bug that fails with a message about node internals starting with this specific
-        // node version in windows. skipping this test for now to ship these agent updates.
-        const skipThis = semver.gte(process.version, '18.17.1') && isWindows && !opts.serverTls
-        if (!skipThis) {
-          await t.rejects(client.get('/'))
-        }
+        await t.rejects(client.get('/'))
       } else {
         const res = await client.get('/')
         t.equal(res.status, 500)

--- a/test/fixtures/setup.js
+++ b/test/fixtures/setup.js
@@ -42,7 +42,6 @@ const createSetup = ({ serverTls, proxyTls, ...baseOpts }) => {
           ...baseOpts.proxy,
           ...opts.proxy,
           agent: new Agent(omit(agentOpts, 'timeouts')),
-          simpleSocks: await import('simple-socks').then(r => r.default),
         })
         await proxy.start()
         t.comment(`Proxy: ${proxy.address} ${proxy.hostAddress}`)


### PR DESCRIPTION
Using `socksv5` now for setting up a small socks proxy server in tests. This library works on Node 18 and 20 which previously were skipped due to a bug in `simple-socks`.