### PR TITLE
Breaking change deps updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "agent-base": "^7.1.0",
-    "http-proxy-agent": "^7.0.0",
+    "http-proxy-agent": "^9.0.0",
     "https-proxy-agent": "^7.0.1",
     "lru-cache": "^11.2.1",
     "socks-proxy-agent": "^8.0.3"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "http-proxy-agent": "^9.0.0",
     "https-proxy-agent": "^9.0.0",
     "lru-cache": "^11.2.1",
-    "socks-proxy-agent": "^8.0.3"
+    "socks-proxy-agent": "^10.0.0"
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "agent-base": "^7.1.0",
     "http-proxy-agent": "^9.0.0",
-    "https-proxy-agent": "^7.0.1",
+    "https-proxy-agent": "^9.0.0",
     "lru-cache": "^11.2.1",
     "socks-proxy-agent": "^8.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "updateNpm": false
   },
   "dependencies": {
-    "agent-base": "^7.1.0",
+    "agent-base": "^9.0.0",
     "http-proxy-agent": "^9.0.0",
     "https-proxy-agent": "^9.0.0",
     "lru-cache": "^11.2.1",


### PR DESCRIPTION
This is a cherry-pick of all the breaking change updates to the http agent libraries.  There are two blockers here:

First, these packages do not have a default exports, so `require` will no longer work.  An [issue has been opened](https://github.com/TooTallNate/proxy-agents/issues/405) seeing if one could be added.  None of them do top level await so it should work just fine.

The second problem is that the `socket error` test in `test/agent.js` fails with an internal node traceback of an `Unhandled error`.  Nothing in the underlying code changed in a way that would explain this.  The most likely culprit is the way we are doing mocking of the underlying `socks` library.  `socks-proxy-agent` is now using `import` and I don't know for sure if `t.mock` is going to catch that.

This is a PR where we can follow the progress of the proxy-agents issue, and either wait till that update or refactor this package to export generator functions instead of bare classes.  We also will need to figure out the mocking/testing error.