### PR TITLE
fix: retain idle timeout for free sockets

### DIFF
--- a/lib/agents.js
+++ b/lib/agents.js
@@ -161,6 +161,16 @@ module.exports = class Agent extends AgentBase {
     return socket
   }
 
+  keepSocketAlive (socket) {
+    const keepAlive = super.keepSocketAlive(socket)
+
+    if (keepAlive && this.#timeouts.idle) {
+      socket.setTimeout(this.#timeouts.idle)
+    }
+
+    return keepAlive
+  }
+
   addRequest (request, options) {
     const proxy = this.#getProxy(options)
     // it would be better to call proxy.addRequest here but this causes the

--- a/test/agent.js
+++ b/test/agent.js
@@ -263,6 +263,25 @@ const agentTest = (t, opts) => {
     })
   })
 
+  t.test('idle timeout destroys completed keep-alive sockets', async (t) => {
+    const idle = 100
+    const { agent, client } = await setup(t, {
+      agent: { maxSockets: 1, timeouts: { idle } },
+    })
+
+    const res = await client.get('/')
+    t.equal(res.status, 200)
+    t.equal(res.result, 'OK!')
+
+    const freeSocket = Object.values(agent.freeSockets).flat()[0]
+    t.ok(freeSocket, 'socket returned to the free socket pool')
+    t.equal(freeSocket.timeout, idle, 'free socket keeps configured idle timeout')
+
+    await timers.setTimeout(idle + 50)
+
+    t.equal(freeSocket.destroyed, true, 'free socket is destroyed after idle timeout')
+  })
+
   t.test('response timeout rejects', async (t) => {
     const { proxy, server, client } = await setup(t, {
       server: { responseDelay: 150 },


### PR DESCRIPTION
Node reapplies the native agent timeout when a completed keep-alive socket is returned to the free socket pool. @npmcli/agent stores idle timeouts in the custom timeouts.idle option and intentionally removes the native timeout option during normalization, so the socket timeout that connect() applied to active requests is cleared after a successful response.

Override keepSocketAlive() to preserve Node's decision about whether the socket should remain pooled, then reapply timeouts.idle to sockets that are kept alive. This keeps the existing custom idle-timeout behavior for in-flight idle requests while also allowing completed free sockets to expire, without setting agent.options.timeout globally and changing proxied active-request behavior.

Add coverage that verifies a successful keep-alive response returns a socket to the free pool, keeps the configured idle timeout on that socket, and destroys it after the idle period.

Closes issue #169 